### PR TITLE
feat(dns): add hostinger_dns_record resource

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -1,0 +1,23 @@
+# hostinger_dns_record
+
+The `hostinger_dns_record` resource allows you to manage DNS records in a Hostinger DNS zone using their public API.
+
+This resource supports full lifecycle operations: create, read, and delete. Updates are handled by replacing the existing record (via `ForceNew`).
+
+---
+
+## Example Usage
+
+```hcl
+provider "hostinger" {
+  api_token = var.hostinger_api_token
+}
+
+resource "hostinger_dns_record" "example" {
+  zone  = "example.com"
+  name  = "api.dev"
+  type  = "CNAME"
+  value = "target.example.com"
+  ttl   = 14400
+}
+```

--- a/examples/dns/basic.tf
+++ b/examples/dns/basic.tf
@@ -2,10 +2,10 @@ provider "hostinger" {
   api_token = var.hostinger_api_token
 }
 
-resource "hostinger_dns_record" "basic" {
+resource "hostinger_dns_record" "record" {
   zone  = var.dns_zone
-  name  = "api"
-  type  = "CNAME"
-  value = var.cname_target
-  ttl   = 14400
+  name  = var.dns_name
+  type  = var.dns_type
+  value = var.dns_value
+  ttl   = var.dns_ttl
 }

--- a/examples/dns/basic.tf
+++ b/examples/dns/basic.tf
@@ -1,0 +1,11 @@
+provider "hostinger" {
+  api_token = var.hostinger_api_token
+}
+
+resource "hostinger_dns_record" "basic" {
+  zone  = var.dns_zone
+  name  = "api"
+  type  = "CNAME"
+  value = var.cname_target
+  ttl   = 14400
+}

--- a/examples/dns/readme.md
+++ b/examples/dns/readme.md
@@ -1,8 +1,8 @@
 # DNS Record Example
 
-This example demonstrates how to create a CNAME record in a Hostinger-managed DNS zone using the `hostinger_dns_record` resource.
+This example demonstrates how to create any type of DNS record (A, AAAA, CNAME, TXT, etc.) in a Hostinger-managed DNS zone using the `hostinger_dns_record` Terraform resource.
 
-## Example
+## Example Usage
 
 ```hcl
 module "dns" {
@@ -10,6 +10,9 @@ module "dns" {
 
   hostinger_api_token = "your-api-token"
   dns_zone            = "example.com"
-  cname_target        = "target.example.com"
+  dns_name            = "api"
+  dns_type            = "A"
+  dns_value           = "192.0.2.100"
+  dns_ttl             = 300
 }
 ```

--- a/examples/dns/readme.md
+++ b/examples/dns/readme.md
@@ -1,0 +1,15 @@
+# DNS Record Example
+
+This example demonstrates how to create a CNAME record in a Hostinger-managed DNS zone using the `hostinger_dns_record` resource.
+
+## Example
+
+```hcl
+module "dns" {
+  source = "./dns_record"
+
+  hostinger_api_token = "your-api-token"
+  dns_zone            = "example.com"
+  cname_target        = "target.example.com"
+}
+```

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -1,14 +1,30 @@
 variable "hostinger_api_token" {
-  description = "Hostinger API token with DNS zone access"
+  description = "Hostinger API token with DNS zone access."
   type        = string
 }
 
 variable "dns_zone" {
-  description = "The DNS zone name (e.g., example.com)"
+  description = "The DNS zone name (e.g., example.com)."
   type        = string
 }
 
-variable "cname_target" {
-  description = "The CNAME target value"
+variable "dns_name" {
+  description = "Subdomain or record name (e.g., 'api', 'www', or '@')."
   type        = string
+}
+
+variable "dns_type" {
+  description = "DNS record type (e.g., A, AAAA, CNAME, TXT, MX, etc.)."
+  type        = string
+}
+
+variable "dns_value" {
+  description = "The value of the DNS record (e.g., IP address, CNAME target, TXT value)."
+  type        = string
+}
+
+variable "dns_ttl" {
+  description = "Time to live (TTL) for the record in seconds."
+  type        = number
+  default     = 14400
 }

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -1,0 +1,14 @@
+variable "hostinger_api_token" {
+  description = "Hostinger API token with DNS zone access"
+  type        = string
+}
+
+variable "dns_zone" {
+  description = "The DNS zone name (e.g., example.com)"
+  type        = string
+}
+
+variable "cname_target" {
+  description = "The CNAME target value"
+  type        = string
+}

--- a/hostinger/dns_record.go
+++ b/hostinger/dns_record.go
@@ -1,0 +1,163 @@
+package hostinger
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceHostingerDNSRecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHostingerDNSRecordCreate,
+		Read:   resourceHostingerDNSRecordRead,
+		Delete: resourceHostingerDNSRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  14400,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceHostingerDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*HostingerClient)
+
+	zone := d.Get("zone").(string)
+	name := d.Get("name").(string)
+	recordType := d.Get("type").(string)
+	value := d.Get("value").(string)
+	ttl := d.Get("ttl").(int)
+
+	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records", zone)
+
+	payload := map[string]interface{}{
+		"name":  name,
+		"type":  recordType,
+		"value": value,
+		"ttl":   ttl,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+client.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("failed to create DNS record: %s", respBody)
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal(respBody, &result)
+
+	id := fmt.Sprintf("%v", result["id"])
+	d.SetId(id)
+
+	return resourceHostingerDNSRecordRead(d, meta)
+}
+
+func resourceHostingerDNSRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*HostingerClient)
+
+	zone := d.Get("zone").(string)
+	id := d.Id()
+
+	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records", zone)
+
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+client.Token)
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed to read DNS records: %s", body)
+	}
+
+	var data struct {
+		Records []map[string]interface{} `json:"records"`
+	}
+	json.Unmarshal(body, &data)
+
+	for _, record := range data.Records {
+		if fmt.Sprintf("%v", record["id"]) == id {
+			d.Set("name", record["name"])
+			d.Set("type", record["type"])
+			d.Set("value", record["value"])
+			d.Set("ttl", int(record["ttl"].(float64)))
+			return nil
+		}
+	}
+	d.SetId("")
+	return nil
+}
+
+func resourceHostingerDNSRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*HostingerClient)
+
+	zone := d.Get("zone").(string)
+	id := d.Id()
+
+	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records/%s", zone, id)
+
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Set("Authorization", "Bearer "+client.Token)
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to delete DNS record: %s", body)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/hostinger/dns_record.go
+++ b/hostinger/dns_record.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -59,7 +60,7 @@ func resourceHostingerDNSRecordCreate(d *schema.ResourceData, meta interface{}) 
 	value := d.Get("value").(string)
 	ttl := d.Get("ttl").(int)
 
-	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records", zone)
+	url := fmt.Sprintf("%s/api/dns/v1/zones/%s/records", client.BaseURL, zone)
 
 	payload := map[string]interface{}{
 		"name":  name,
@@ -73,8 +74,8 @@ func resourceHostingerDNSRecordCreate(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+client.Token)
-	req.Header.Set("Content-Type", "application/json")
+
+	client.addStandardHeaders(req)
 
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {
@@ -102,10 +103,10 @@ func resourceHostingerDNSRecordRead(d *schema.ResourceData, meta interface{}) er
 	zone := d.Get("zone").(string)
 	id := d.Id()
 
-	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records", zone)
+	url := fmt.Sprintf("%s/api/dns/v1/zones/%s/records", client.BaseURL, zone)
 
 	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Set("Authorization", "Bearer "+client.Token)
+	client.addStandardHeaders(req)
 
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {
@@ -132,6 +133,7 @@ func resourceHostingerDNSRecordRead(d *schema.ResourceData, meta interface{}) er
 			return nil
 		}
 	}
+
 	d.SetId("")
 	return nil
 }
@@ -142,10 +144,10 @@ func resourceHostingerDNSRecordDelete(d *schema.ResourceData, meta interface{}) 
 	zone := d.Get("zone").(string)
 	id := d.Id()
 
-	url := fmt.Sprintf("https://developers.hostinger.com/api/dns/v1/zones/%s/records/%s", zone, id)
+	url := fmt.Sprintf("%s/api/dns/v1/zones/%s/records/%s", client.BaseURL, zone, id)
 
 	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Set("Authorization", "Bearer "+client.Token)
+	client.addStandardHeaders(req)
 
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {

--- a/hostinger/dns_record_test.go
+++ b/hostinger/dns_record_test.go
@@ -1,0 +1,37 @@
+package hostinger
+
+import (
+	"testing"
+)
+
+func TestResourceHostingerDNSRecord_Schema(t *testing.T) {
+	resource := resourceHostingerDNSRecord()
+
+	if err := resource.InternalValidate(resource.Schema, true); err != nil {
+		t.Fatalf("schema validation failed: %s", err)
+	}
+
+	expectedFields := []string{"id", "zone", "name", "type", "value", "ttl"}
+
+	for _, field := range expectedFields {
+		if _, ok := resource.Schema[field]; !ok {
+			t.Errorf("expected field %q not found in schema", field)
+		}
+	}
+}
+
+func TestResourceHostingerDNSRecord_BasicCreate(t *testing.T) {
+	resource := resourceHostingerDNSRecord()
+	data := resource.TestResourceData()
+
+	data.Set("zone", "example.com")
+	data.Set("name", "test")
+	data.Set("type", "CNAME")
+	data.Set("value", "target.example.com")
+	data.Set("ttl", 14400)
+
+	// Just check that Set works without panic and has the right values
+	if v := data.Get("zone"); v != "example.com" {
+		t.Errorf("expected zone to be 'example.com', got %v", v)
+	}
+}

--- a/hostinger/provider.go
+++ b/hostinger/provider.go
@@ -28,6 +28,7 @@ func Provider() *schema.Provider {
             "hostinger_vps_templates":      dataSourceHostingerVPSTemplates(),
             "hostinger_vps_data_centers":   dataSourceHostingerVPSDataCenters(),
             "hostinger_vps_plans":          dataSourceHostingerVPSPlans(),
+            "hostinger_dns_record": resourceHostingerDNSRecord(),
         },
         ConfigureContextFunc: providerConfigure,
     }

--- a/hostinger/provider.go
+++ b/hostinger/provider.go
@@ -28,7 +28,7 @@ func Provider() *schema.Provider {
             "hostinger_vps_templates":      dataSourceHostingerVPSTemplates(),
             "hostinger_vps_data_centers":   dataSourceHostingerVPSDataCenters(),
             "hostinger_vps_plans":          dataSourceHostingerVPSPlans(),
-            "hostinger_dns_record": resourceHostingerDNSRecord(),
+            "hostinger_dns_record":         resourceHostingerDNSRecord(),
         },
         ConfigureContextFunc: providerConfigure,
     }


### PR DESCRIPTION
This PR adds a new resource hostinger_dns_record to manage DNS records using the Hostinger DNS API.

	•	Supports record types like CNAME, A, TXT, etc.
	•	Implements Create, Read, and Delete lifecycle (no Update, marked ForceNew).
	•	Includes complete documentation(examples/dns/readme.md)  and Terraform example (examples/dns).
	•	Unit-tested with InternalValidate() and validated through acceptance test