### PR TITLE
fix(dns): set overwrite to false in DNS record creation payload

### DIFF
--- a/hostinger/dns_record.go
+++ b/hostinger/dns_record.go
@@ -64,7 +64,7 @@ func resourceHostingerDNSRecordCreate(d *schema.ResourceData, meta interface{}) 
 	url := fmt.Sprintf("%s/api/dns/v1/zones/%s", client.BaseURL, zone)
 
 	payload := map[string]interface{}{
-		"overwrite": true,
+		"overwrite": false,
 		"zone": []map[string]interface{}{
 			{
 				"name": name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the default behavior when creating DNS records to prevent accidental overwrites of existing configurations. The system now preserves existing DNS records unless explicitly overwritten.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->