### PR TITLE
feature(vps): Add terraform import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This provider integrates with Hostinger's Public API to manage VPS servers, post
 
 - ✅ Create and delete VPS servers
 - 🔄 In-place updates for hostname, SSH keys, OS template
+- 📦 **Import existing VPS instances** with automatic configuration retrieval
 - 🔐 Attach SSH keys (inline or existing)
 - 📜 Upload post-install scripts
 - 🔎 Validate `plan`, `template_id`, and `data_center_id` before provisioning
@@ -38,7 +39,7 @@ terraform {
   required_providers {
     hostinger = {
       source = "hostinger/hostinger"
-      version = "0.1.19"
+      version = "0.1.21"
     }
   }
 }
@@ -96,6 +97,32 @@ output "available_templates" {
 - `hostinger_vps` — Provisions a VPS
 - `hostinger_vps_ssh_key` — Manages account-level SSH keys
 - `hostinger_vps_post_install_script` — Upload post-install scripts
+
+---
+
+## Importing Existing Resources
+
+You can import existing VPS instances into your Terraform state. The import process automatically retrieves all configuration details including plan, data center, and template information:
+
+```bash
+# Import a VPS using its ID
+terraform import hostinger_vps.my_vps 1092628
+```
+
+After importing, check the imported values:
+```bash
+terraform state show hostinger_vps.my_vps
+```
+
+Then add the resource to your configuration with the imported values:
+```hcl
+resource "hostinger_vps" "my_vps" {
+  plan           = "KVM 8"              # Auto-retrieved during import
+  data_center_id = 22                   # Auto-retrieved during import
+  template_id    = 1141                 # Auto-retrieved during import
+  hostname       = "srv1092628.hstgr.cloud"
+}
+```
 
 ---
 

--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -43,3 +43,26 @@ resource "hostinger_vps" "box" {
 - `status` – Status of the VPS provisioning.
 - `vps_id` – Same as `id`, retained for convenience and backward compatibility.
 
+---
+
+## Import
+
+Existing VPS instances can be imported using their VPS ID. The import process will automatically retrieve all necessary configuration details from the Hostinger API, including plan, data center, and template information.
+
+```bash
+terraform import hostinger_vps.example 123456
+```
+
+After importing, run `terraform state show hostinger_vps.example` to see all the imported values, then add them to your configuration file:
+
+```hcl
+resource "hostinger_vps" "example" {
+  plan           = "KVM 8"              # Automatically retrieved
+  data_center_id = 22                   # Automatically retrieved
+  template_id    = 1141                 # Automatically retrieved
+  hostname       = "srv123456.hstgr.cloud" # Automatically retrieved
+}
+```
+
+All fields including `plan`, `data_center_id`, `template_id`, `hostname`, `ipv4_address`, and `ipv6_address` are automatically populated from the imported resource, providing a seamless import experience similar to major cloud providers.
+

--- a/hostinger/provider.go
+++ b/hostinger/provider.go
@@ -49,6 +49,6 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	}
 
 	// Initialize the Hostinger API client
-	client := NewHostingerClient(token, "0.1.19")
+	client := NewHostingerClient(token, "0.1.21")
 	return client, diags
 }


### PR DESCRIPTION
Resolves: https://github.com/hostinger/terraform-provider-hostinger/issues/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to import existing VPS instances with automatic configuration retrieval, including plan, data center, template, hostname, and IP addresses.

* **Documentation**
  * Comprehensive "Importing Existing Resources" guide with step-by-step instructions and configuration examples.
  * Updated minimum provider version requirement to 0.1.21.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->