### PR TITLE
Adding support to firewall and firewall rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.1'
+        go-version-file: 'go.mod'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.test
 *.out
 
+# GoReleaser output
+dist/
+
 # Terraform related
 .terraform/
 *.tfstate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: [ 'zip' ]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ resource "hostinger_vps" "web" {
 | `hostinger_vps` | Provision and manage a VPS instance |
 | `hostinger_vps_post_install_script` | Create a reusable post-install script |
 | `hostinger_vps_ssh_key` | Add and attach an SSH key to a VPS |
+| `hostinger_vps_firewall` | Manage a VPS firewall and its rules |
+| `hostinger_vps_firewall_activation` | Activate a firewall on a VPS instance |
 
 ---
 

--- a/docs/resources/vps_firewall.md
+++ b/docs/resources/vps_firewall.md
@@ -1,0 +1,68 @@
+# hostinger_vps_firewall
+
+The `hostinger_vps_firewall` resource manages a VPS firewall and its rules on Hostinger.
+
+A firewall **drops all incoming traffic by default**, so every rule you add grants access for a specific protocol and port — rules are always `accept`. Rules are declared as an ordered list of nested `rule` blocks. Editing a rule in place updates it via the API and preserves its rule ID; appending blocks creates rules and removing trailing blocks deletes them.
+
+A firewall on its own does nothing until it is activated on a VPS. Use [`hostinger_vps_firewall_activation`](vps_firewall_activation.md) to attach it to a virtual machine.
+
+---
+
+## Example Usage
+
+```hcl
+resource "hostinger_vps_firewall" "web" {
+  name = "web-fw"
+
+  rule {
+    protocol      = "SSH"
+    port          = "22"
+    source        = "custom"
+    source_detail = "10.0.0.0/24"
+  }
+
+  rule {
+    protocol      = "HTTPS"
+    port          = "443"
+    source        = "any"
+    source_detail = "any"
+  }
+}
+```
+
+---
+
+## Argument Reference
+
+- `name` – (Required, ForceNew) Name of the firewall. The Hostinger API has no rename endpoint, so changing the name **replaces** the firewall. Because a replaced firewall is deleted (and automatically deactivated from any attached VPS), there is a brief gap in protection during the replace.
+- `rule` – (Optional) An ordered list of accept rules. Each `rule` block supports:
+  - `protocol` – (Required) One of `TCP`, `UDP`, `ICMP`, `GRE`, `any`, `ESP`, `AH`, `ICMPv6`, `SSH`, `HTTP`, `HTTPS`, `MySQL`, `PostgreSQL`.
+  - `port` – (Required) A single port (e.g. `"443"`) or a range (e.g. `"1024:2048"`).
+  - `source` – (Required) `any` or `custom`.
+  - `source_detail` – (Required) `any`, a single IP, a CIDR, or an IP range.
+
+> **Note:** Adding, changing, or removing a rule causes the firewall to lose sync with any VPS it is activated on (`is_synced` becomes `false`). Re-apply the rules to the VM with a sync — see [`hostinger_vps_firewall_activation`](vps_firewall_activation.md).
+
+---
+
+## Attributes Reference
+
+- `id` – ID of the firewall in Hostinger's system.
+- `is_synced` – Whether the firewall is in sync with the VPS instances it is activated on.
+- `created_at` – Timestamp when the firewall was created.
+- `updated_at` – Timestamp when the firewall was last updated.
+- Each `rule` additionally exports:
+  - `id` – Server-assigned ID of the rule.
+  - `action` – Always `accept` (the firewall drops everything else by default).
+
+---
+
+## Import
+
+Existing firewalls can be imported using their numeric firewall ID:
+
+```bash
+terraform import hostinger_vps_firewall.web 65224
+```
+
+After importing, run `terraform state show hostinger_vps_firewall.web` to view the imported rules, then add matching `name` and `rule` blocks to your configuration.

--- a/docs/resources/vps_firewall_activation.md
+++ b/docs/resources/vps_firewall_activation.md
@@ -1,0 +1,50 @@
+# hostinger_vps_firewall_activation
+
+The `hostinger_vps_firewall_activation` resource attaches a [`hostinger_vps_firewall`](vps_firewall.md) to a VPS instance. Creating the resource activates the firewall on the virtual machine; destroying it deactivates the firewall.
+
+Only **one firewall can be active on a VM at a time** — activating a second firewall on the same VM will fail server-side.
+
+---
+
+## Example Usage
+
+```hcl
+resource "hostinger_vps_firewall_activation" "web" {
+  firewall_id        = hostinger_vps_firewall.web.id
+  virtual_machine_id = hostinger_vps.complete.id
+
+  # Re-sync rules to the VM whenever the firewall's rule set changes.
+  triggers = {
+    rules = sha1(jsonencode(hostinger_vps_firewall.web.rule))
+  }
+}
+```
+
+---
+
+## Argument Reference
+
+- `firewall_id` – (Required, ForceNew) ID of the firewall to activate.
+- `virtual_machine_id` – (Required, ForceNew) ID of the virtual machine to activate the firewall on.
+- `triggers` – (Optional) An arbitrary map of strings. Whenever any value changes, the firewall is **synced** (re-applied) to the virtual machine on the next `apply`. This is the mechanism for pushing rule changes to a running VM.
+
+> **Sync is manual.** Changing a firewall's rules leaves it out of sync with the VM (`is_synced` becomes `false`); the change does **not** reach the VM until a sync happens. Wire `triggers` to your rule set (as shown above) to sync on apply, or run a sync yourself via the Hostinger API / hPanel.
+
+---
+
+## Attributes Reference
+
+- `id` – Composite ID in the form `firewallId/virtualMachineId`.
+- `is_synced` – Whether the firewall is currently in sync with the virtual machine.
+
+> **Limitation:** The Hostinger API does not expose which VM a firewall is active on, so this resource cannot detect if the firewall was deactivated out-of-band. Read only confirms the firewall still exists and reports its sync state.
+
+---
+
+## Import
+
+Existing activations can be imported using a `firewallId/virtualMachineId` composite ID:
+
+```bash
+terraform import hostinger_vps_firewall_activation.web 65224/1268054
+```

--- a/examples/vps/firewall.tf
+++ b/examples/vps/firewall.tf
@@ -1,0 +1,49 @@
+# Firewall example: a firewall with accept rules, attached to a VPS.
+#
+# The firewall drops all incoming traffic by default, so each rule opens access
+# for a specific protocol/port. Attaching the firewall to a VPS is a separate
+# resource; after changing rules you sync them to the VM by bumping `triggers`.
+
+provider "hostinger" {
+  api_token = var.api_token
+}
+
+resource "hostinger_vps_firewall" "web" {
+  name = "web-fw"
+
+  # Allow SSH only from an internal CIDR.
+  rule {
+    protocol      = "SSH"
+    port          = "22"
+    source        = "custom"
+    source_detail = "10.0.0.0/24"
+  }
+
+  # Allow HTTPS from anywhere.
+  rule {
+    protocol      = "HTTPS"
+    port          = "443"
+    source        = "any"
+    source_detail = "any"
+  }
+}
+
+# Attach the firewall to a VPS. Create activates it; destroy deactivates it.
+resource "hostinger_vps_firewall_activation" "web" {
+  firewall_id        = hostinger_vps_firewall.web.id
+  virtual_machine_id = hostinger_vps.complete.id
+
+  # Re-sync the firewall to the VM whenever the rule set changes. Sync is manual:
+  # without this, rule changes won't take effect on the VM until you sync via the API.
+  triggers = {
+    rules = sha1(jsonencode(hostinger_vps_firewall.web.rule))
+  }
+}
+
+output "firewall_id" {
+  value = hostinger_vps_firewall.web.id
+}
+
+output "firewall_is_synced" {
+  value = hostinger_vps_firewall_activation.web.is_synced
+}

--- a/hostinger/client.go
+++ b/hostinger/client.go
@@ -92,13 +92,13 @@ func (c *HostingerClient) GetSubscriptionDetails(subscriptionID string) (*Subscr
 		return nil, err
 	}
 	c.addStandardHeaders(req)
-	
+
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	
+
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
@@ -106,7 +106,7 @@ func (c *HostingerClient) GetSubscriptionDetails(subscriptionID string) (*Subscr
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("failed to get subscription details (HTTP %d): %s", resp.StatusCode, string(body))
 	}
-	
+
 	var details SubscriptionDetails
 	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
 		return nil, fmt.Errorf("invalid subscription details response: %w", err)
@@ -116,11 +116,11 @@ func (c *HostingerClient) GetSubscriptionDetails(subscriptionID string) (*Subscr
 
 // SubscriptionDetails contains detailed subscription information including the plan
 type SubscriptionDetails struct {
-	ID       string `json:"id"`
-	Status   string `json:"status"`
-	Plan     string `json:"plan"`
-	ItemID   string `json:"item_id"`
-	Product  struct {
+	ID      string `json:"id"`
+	Status  string `json:"status"`
+	Plan    string `json:"plan"`
+	ItemID  string `json:"item_id"`
+	Product struct {
 		Type       string `json:"type"`
 		ResourceID int    `json:"resource_id"`
 	} `json:"product"`
@@ -230,15 +230,17 @@ type VirtualMachine struct {
 	Plan           string      `json:"plan,omitempty"`
 	DataCenterID   int         `json:"data_center_id,omitempty"`
 	TemplateID     int         `json:"template_id,omitempty"`
-	Template       interface{} `json:"template,omitempty"` // Can be string or object
-	DataCenter     interface{} `json:"data_center,omitempty"` // Can be string or object  
+	Template       interface{} `json:"template,omitempty"`    // Can be string or object
+	DataCenter     interface{} `json:"data_center,omitempty"` // Can be string or object
 	OS             string      `json:"os,omitempty"`
 	OSName         string      `json:"os_name,omitempty"`
 	Resources      struct {
-		CPU    int `json:"cpu"`
-		RAM    int `json:"ram"`
-		Disk   int `json:"disk"`
+		CPU  int `json:"cpu"`
+		RAM  int `json:"ram"`
+		Disk int `json:"disk"`
 	} `json:"resources,omitempty"`
+	// FirewallGroupID is the ID of the firewall currently active on the VM, or nil if disabled.
+	FirewallGroupID *int `json:"firewall_group_id,omitempty"`
 }
 type IPAddress struct {
 	Address string `json:"address"`
@@ -374,7 +376,7 @@ func (c *HostingerClient) GetVirtualMachineWithFullDetails(vmID int) (*VirtualMa
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Extract IDs from template/datacenter if they're objects
 	if vm.Template != nil {
 		if tmplObj, ok := vm.Template.(map[string]interface{}); ok {
@@ -385,7 +387,7 @@ func (c *HostingerClient) GetVirtualMachineWithFullDetails(vmID int) (*VirtualMa
 			}
 		}
 	}
-	
+
 	if vm.DataCenter != nil {
 		if dcObj, ok := vm.DataCenter.(map[string]interface{}); ok {
 			if id, exists := dcObj["id"]; exists {
@@ -395,7 +397,7 @@ func (c *HostingerClient) GetVirtualMachineWithFullDetails(vmID int) (*VirtualMa
 			}
 		}
 	}
-	
+
 	// Try to get subscription details to enrich with plan information
 	if vm.SubscriptionID != "" {
 		subDetails, err := c.GetSubscriptionDetails(vm.SubscriptionID)
@@ -409,7 +411,7 @@ func (c *HostingerClient) GetVirtualMachineWithFullDetails(vmID int) (*VirtualMa
 		}
 		// We don't fail if subscription details can't be fetched, we just use what we have
 	}
-	
+
 	return vm, nil
 }
 

--- a/hostinger/provider.go
+++ b/hostinger/provider.go
@@ -23,6 +23,8 @@ func Provider() *schema.Provider {
 			"hostinger_vps":                     resourceHostingerVPS(),
 			"hostinger_vps_post_install_script": resourceHostingerVPSPostInstallScript(),
 			"hostinger_vps_ssh_key":             resourceHostingerVPSSSHKey(),
+			"hostinger_vps_firewall":            resourceHostingerVPSFirewall(),
+			"hostinger_vps_firewall_activation": resourceHostingerVPSFirewallActivation(),
 			"hostinger_dns_record":              resourceHostingerDNSRecord(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/hostinger/vps_firewall.go
+++ b/hostinger/vps_firewall.go
@@ -1,0 +1,497 @@
+package hostinger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// firewallProtocols are the protocol values accepted by the Hostinger firewall API.
+var firewallProtocols = []string{
+	"TCP", "UDP", "ICMP", "GRE", "any", "ESP", "AH", "ICMPv6",
+	"SSH", "HTTP", "HTTPS", "MySQL", "PostgreSQL",
+}
+
+// Firewall mirrors VPS.V1.Firewall.FirewallResource.
+type Firewall struct {
+	ID        int            `json:"id"`
+	Name      string         `json:"name"`
+	IsSynced  bool           `json:"is_synced"`
+	Rules     []FirewallRule `json:"rules"`
+	CreatedAt string         `json:"created_at"`
+	UpdatedAt string         `json:"updated_at"`
+}
+
+// FirewallRule mirrors VPS.V1.Firewall.FirewallRuleResource.
+type FirewallRule struct {
+	ID           int    `json:"id"`
+	Action       string `json:"action"`
+	Protocol     string `json:"protocol"`
+	Port         string `json:"port"`
+	Source       string `json:"source"`
+	SourceDetail string `json:"source_detail"`
+}
+
+func resourceHostingerVPSFirewall() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostingerVPSFirewallCreate,
+		ReadContext:   resourceHostingerVPSFirewallRead,
+		UpdateContext: resourceHostingerVPSFirewallUpdate,
+		DeleteContext: resourceHostingerVPSFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHostingerVPSFirewallImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the firewall. The Hostinger API has no rename endpoint, so changing this replaces the firewall.",
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"rule": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Ordered list of accept rules. The firewall drops all incoming traffic by default, so every rule grants access for a protocol/port. Editing a rule in place updates it via the API (keeping its ID); removing the last rules deletes them and appending new ones creates them.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Protocol the rule applies to.",
+							ValidateFunc: validation.StringInSlice(firewallProtocols, false),
+						},
+						"port": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Destination port or port range, e.g. \"443\" or \"1024:2048\".",
+							ValidateFunc: validateFirewallPort,
+						},
+						"source": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Source kind: \"any\" or \"custom\".",
+							ValidateFunc: validation.StringInSlice([]string{"any", "custom"}, false),
+						},
+						"source_detail": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Source detail: \"any\", a single IP, a CIDR, or an IP range.",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Server-assigned ID of the rule.",
+						},
+						"action": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Action applied by the rule. Always \"accept\" (the firewall drops everything else by default).",
+						},
+					},
+				},
+			},
+			"is_synced": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the firewall is in sync with the VPS instances it is activated on. Changing rules sets this to false until a sync is performed.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp when the firewall was created.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp when the firewall was last updated.",
+			},
+		},
+	}
+}
+
+func resourceHostingerVPSFirewallCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	fw, err := client.CreateFirewall(d.Get("name").(string))
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to create firewall: %w", err))
+	}
+	// Set the ID immediately so partial failures while creating rules remain tracked.
+	d.SetId(strconv.Itoa(fw.ID))
+
+	if v, ok := d.GetOk("rule"); ok {
+		for _, raw := range v.([]interface{}) {
+			rule := expandFirewallRule(raw.(map[string]interface{}))
+			if _, err := client.CreateFirewallRule(fw.ID, rule); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to create firewall rule (%s/%s): %w", rule.Protocol, rule.Port, err))
+			}
+		}
+	}
+
+	return resourceHostingerVPSFirewallRead(ctx, d, m)
+}
+
+func resourceHostingerVPSFirewallRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("invalid firewall ID %q: %w", d.Id(), err))
+	}
+
+	fw, err := client.GetFirewall(id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed to read firewall: %w", err))
+	}
+
+	if err := d.Set("name", fw.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set name: %w", err))
+	}
+	if err := d.Set("is_synced", fw.IsSynced); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set is_synced: %w", err))
+	}
+	if err := d.Set("created_at", fw.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set created_at: %w", err))
+	}
+	if err := d.Set("updated_at", fw.UpdatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set updated_at: %w", err))
+	}
+	if err := d.Set("rule", flattenFirewallRules(fw.Rules)); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set rule: %w", err))
+	}
+
+	return nil
+}
+
+func resourceHostingerVPSFirewallUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("invalid firewall ID %q: %w", d.Id(), err))
+	}
+
+	if d.HasChange("rule") {
+		oldRaw, newRaw := d.GetChange("rule")
+		updates, creates, deletes := planFirewallRuleChanges(oldRaw.([]interface{}), newRaw.([]interface{}))
+
+		// Update edited rules in place via PUT so they keep their server-assigned ID.
+		for _, u := range updates {
+			if _, err := client.UpdateFirewallRule(id, u.ID, u.Rule); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to update firewall rule %d: %w", u.ID, err))
+			}
+		}
+		// Delete rules removed from the end of the list.
+		for _, ruleID := range deletes {
+			if err := client.DeleteFirewallRule(id, ruleID); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to delete firewall rule %d: %w", ruleID, err))
+			}
+		}
+		// Create rules appended to the list.
+		for _, rule := range creates {
+			if _, err := client.CreateFirewallRule(id, rule); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to create firewall rule (%s/%s): %w", rule.Protocol, rule.Port, err))
+			}
+		}
+	}
+
+	return resourceHostingerVPSFirewallRead(ctx, d, m)
+}
+
+func resourceHostingerVPSFirewallDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("invalid firewall ID %q: %w", d.Id(), err))
+	}
+
+	if err := client.DeleteFirewall(id); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to delete firewall: %w", err))
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceHostingerVPSFirewallImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if _, err := strconv.Atoi(d.Id()); err != nil {
+		return nil, fmt.Errorf("invalid firewall import ID %q: expected a numeric firewall ID", d.Id())
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+// ruleUpdate pairs an existing rule's server-assigned ID with the desired new content,
+// for an in-place update via the PUT endpoint.
+type ruleUpdate struct {
+	ID   int
+	Rule FirewallRule
+}
+
+// planFirewallRuleChanges diffs the old and new rule lists positionally and returns the
+// in-place updates (PUT), appended creations (POST), and removed rule IDs (DELETE) needed
+// to converge. Positional diffing lets an edited rule keep its server-assigned ID via the
+// update endpoint instead of being destroyed and recreated. Only the four user-supplied
+// fields are compared, so the computed id/action attributes never trigger a spurious update.
+func planFirewallRuleChanges(oldList, newList []interface{}) (updates []ruleUpdate, creates []FirewallRule, deletes []int) {
+	overlap := len(oldList)
+	if len(newList) < overlap {
+		overlap = len(newList)
+	}
+	for i := 0; i < overlap; i++ {
+		oldMap := oldList[i].(map[string]interface{})
+		newRule := expandFirewallRule(newList[i].(map[string]interface{}))
+		if expandFirewallRule(oldMap) != newRule {
+			updates = append(updates, ruleUpdate{ID: oldMap["id"].(int), Rule: newRule})
+		}
+	}
+	for i := overlap; i < len(oldList); i++ {
+		deletes = append(deletes, oldList[i].(map[string]interface{})["id"].(int))
+	}
+	for i := overlap; i < len(newList); i++ {
+		creates = append(creates, expandFirewallRule(newList[i].(map[string]interface{})))
+	}
+	return updates, creates, deletes
+}
+
+func expandFirewallRule(m map[string]interface{}) FirewallRule {
+	return FirewallRule{
+		Protocol:     m["protocol"].(string),
+		Port:         m["port"].(string),
+		Source:       m["source"].(string),
+		SourceDetail: m["source_detail"].(string),
+	}
+}
+
+func flattenFirewallRules(rules []FirewallRule) []interface{} {
+	// Sort by server-assigned ID so the stored order is stable across reads, regardless
+	// of the order the API returns rules in. Combined with positional diffing in Update,
+	// this keeps the list order consistent with the configuration after an apply.
+	sorted := make([]FirewallRule, len(rules))
+	copy(sorted, rules)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	out := make([]interface{}, 0, len(sorted))
+	for _, r := range sorted {
+		out = append(out, map[string]interface{}{
+			"id":            r.ID,
+			"action":        r.Action,
+			"protocol":      r.Protocol,
+			"port":          r.Port,
+			"source":        r.Source,
+			"source_detail": r.SourceDetail,
+		})
+	}
+	return out
+}
+
+// validateFirewallPort accepts a single port or an inclusive "lo:hi" range, each port
+// in 1-65535 and lo <= hi, so out-of-range or reversed ports are rejected at plan time
+// instead of failing later with a raw HTTP 422 from the API.
+func validateFirewallPort(i interface{}, k string) (warnings []string, errs []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	parsePort := func(s string) (int, error) {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, fmt.Errorf("%q is not a valid port number", s)
+		}
+		if n < 1 || n > 65535 {
+			return 0, fmt.Errorf("port %d is out of range (must be 1-65535)", n)
+		}
+		return n, nil
+	}
+
+	parts := strings.Split(v, ":")
+	switch len(parts) {
+	case 1:
+		if _, err := parsePort(parts[0]); err != nil {
+			errs = append(errs, fmt.Errorf("invalid %q: %w", k, err))
+		}
+	case 2:
+		lo, err := parsePort(parts[0])
+		if err != nil {
+			return nil, []error{fmt.Errorf("invalid %q: %w", k, err)}
+		}
+		hi, err := parsePort(parts[1])
+		if err != nil {
+			return nil, []error{fmt.Errorf("invalid %q: %w", k, err)}
+		}
+		if lo > hi {
+			errs = append(errs, fmt.Errorf("invalid %q: range start %d must not exceed end %d", k, lo, hi))
+		}
+	default:
+		errs = append(errs, fmt.Errorf("invalid %q %q: expected a single port (e.g. \"443\") or a range (e.g. \"1024:2048\")", k, v))
+	}
+	return warnings, errs
+}
+
+// firewallRuleRequestBody is the payload the rule create/update endpoints accept.
+// action and id are read-only and must not be sent.
+func firewallRuleRequestBody(r FirewallRule) map[string]string {
+	return map[string]string{
+		"protocol":      r.Protocol,
+		"port":          r.Port,
+		"source":        r.Source,
+		"source_detail": r.SourceDetail,
+	}
+}
+
+// HostingerClient implementations:
+
+func (c *HostingerClient) CreateFirewall(name string) (*Firewall, error) {
+	url := c.BaseURL + "/api/vps/v1/firewall"
+	data, _ := json.Marshal(map[string]string{"name": name})
+
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("create firewall failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+
+	var res Firewall
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *HostingerClient) GetFirewall(id int) (*Firewall, error) {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d", c.BaseURL, id)
+	req, _ := http.NewRequest("GET", url, nil)
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("read firewall failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+
+	var res Firewall
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *HostingerClient) DeleteFirewall(id int) error {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d", c.BaseURL, id)
+	req, _ := http.NewRequest("DELETE", url, nil)
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete firewall failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+	return nil
+}
+
+func (c *HostingerClient) CreateFirewallRule(firewallID int, r FirewallRule) (*FirewallRule, error) {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d/rules", c.BaseURL, firewallID)
+	data, _ := json.Marshal(firewallRuleRequestBody(r))
+
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("create firewall rule failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+
+	var res FirewallRule
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *HostingerClient) UpdateFirewallRule(firewallID, ruleID int, r FirewallRule) (*FirewallRule, error) {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d/rules/%d", c.BaseURL, firewallID, ruleID)
+	data, _ := json.Marshal(firewallRuleRequestBody(r))
+
+	req, _ := http.NewRequest("PUT", url, bytes.NewBuffer(data))
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("update firewall rule failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+
+	var res FirewallRule
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *HostingerClient) DeleteFirewallRule(firewallID, ruleID int) error {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d/rules/%d", c.BaseURL, firewallID, ruleID)
+	req, _ := http.NewRequest("DELETE", url, nil)
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete firewall rule failed (HTTP %d): %s", resp.StatusCode, msg)
+	}
+	return nil
+}

--- a/hostinger/vps_firewall_activation.go
+++ b/hostinger/vps_firewall_activation.go
@@ -1,0 +1,225 @@
+package hostinger
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// FirewallAction mirrors VPS.V1.Action.ActionResource.
+type FirewallAction struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+func resourceHostingerVPSFirewallActivation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostingerVPSFirewallActivationCreate,
+		ReadContext:   resourceHostingerVPSFirewallActivationRead,
+		UpdateContext: resourceHostingerVPSFirewallActivationUpdate,
+		DeleteContext: resourceHostingerVPSFirewallActivationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHostingerVPSFirewallActivationImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"firewall_id": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "ID of the firewall to activate on the virtual machine.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"virtual_machine_id": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "ID of the virtual machine to activate the firewall on. Only one firewall can be active on a VM at a time.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"triggers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Arbitrary map whose change triggers a firewall sync on the virtual machine. Use it to re-apply rules after they change, e.g. triggers = { rules = sha1(jsonencode(hostinger_vps_firewall.web.rule)) }.",
+			},
+			"is_synced": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the firewall is currently in sync with the virtual machine. Changing rules on the firewall sets this to false until a sync is performed.",
+			},
+		},
+	}
+}
+
+func resourceHostingerVPSFirewallActivationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+	firewallID := d.Get("firewall_id").(int)
+	vmID := d.Get("virtual_machine_id").(int)
+
+	if _, err := client.ActivateFirewall(firewallID, vmID); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to activate firewall %d on VM %d: %w", firewallID, vmID, err))
+	}
+
+	d.SetId(fmt.Sprintf("%d/%d", firewallID, vmID))
+	return resourceHostingerVPSFirewallActivationRead(ctx, d, m)
+}
+
+func resourceHostingerVPSFirewallActivationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	firewallID, vmID, err := parseFirewallActivationID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Detect drift on this specific VM: the VM reports the firewall currently active
+	// on it via firewall_group_id. If it no longer points at our firewall (deactivated
+	// out-of-band, or another firewall activated on the VM — only one can be active at a
+	// time), the activation is gone, so drop it from state.
+	vm, err := client.GetVirtualMachine(vmID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed to read virtual machine %d: %w", vmID, err))
+	}
+	if vm.FirewallGroupID == nil || *vm.FirewallGroupID != firewallID {
+		d.SetId("")
+		return nil
+	}
+
+	fw, err := client.GetFirewall(firewallID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed to read firewall %d: %w", firewallID, err))
+	}
+
+	if err := d.Set("firewall_id", firewallID); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set firewall_id: %w", err))
+	}
+	if err := d.Set("virtual_machine_id", vmID); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set virtual_machine_id: %w", err))
+	}
+	if err := d.Set("is_synced", fw.IsSynced); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set is_synced: %w", err))
+	}
+
+	return nil
+}
+
+func resourceHostingerVPSFirewallActivationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	// Only "triggers" is updatable; firewall_id and virtual_machine_id are ForceNew.
+	// A change to triggers re-applies (syncs) the firewall to the VM.
+	if d.HasChange("triggers") {
+		firewallID, vmID, err := parseFirewallActivationID(d.Id())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if _, err := client.SyncFirewall(firewallID, vmID); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to sync firewall %d on VM %d: %w", firewallID, vmID, err))
+		}
+	}
+
+	return resourceHostingerVPSFirewallActivationRead(ctx, d, m)
+}
+
+func resourceHostingerVPSFirewallActivationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*HostingerClient)
+
+	firewallID, vmID, err := parseFirewallActivationID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if _, err := client.DeactivateFirewall(firewallID, vmID); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to deactivate firewall %d on VM %d: %w", firewallID, vmID, err))
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceHostingerVPSFirewallActivationImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if _, _, err := parseFirewallActivationID(d.Id()); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+// parseFirewallActivationID splits a "firewallId/virtualMachineId" composite ID.
+func parseFirewallActivationID(id string) (int, int, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid firewall activation ID %q: expected \"firewallId/virtualMachineId\"", id)
+	}
+	firewallID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid firewall ID in %q: %w", id, err)
+	}
+	vmID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid virtual machine ID in %q: %w", id, err)
+	}
+	return firewallID, vmID, nil
+}
+
+// HostingerClient implementations:
+
+func (c *HostingerClient) ActivateFirewall(firewallID, vmID int) (*FirewallAction, error) {
+	return c.firewallVMAction("activate", firewallID, vmID)
+}
+
+func (c *HostingerClient) DeactivateFirewall(firewallID, vmID int) (*FirewallAction, error) {
+	return c.firewallVMAction("deactivate", firewallID, vmID)
+}
+
+func (c *HostingerClient) SyncFirewall(firewallID, vmID int) (*FirewallAction, error) {
+	return c.firewallVMAction("sync", firewallID, vmID)
+}
+
+// firewallVMAction performs one of the activate/deactivate/sync firewall operations,
+// which share an identical request/response shape.
+func (c *HostingerClient) firewallVMAction(action string, firewallID, vmID int) (*FirewallAction, error) {
+	url := fmt.Sprintf("%s/api/vps/v1/firewall/%d/%s/%d", c.BaseURL, firewallID, action, vmID)
+	req, _ := http.NewRequest("POST", url, nil)
+	c.addStandardHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%s firewall failed (HTTP %d): %s", action, resp.StatusCode, msg)
+	}
+
+	var res FirewallAction
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+	// A 200 only means the action was accepted; the action itself can still report
+	// failure via its state (success|error|delayed|sent|created). Surface a hard
+	// error so a failed activate/deactivate/sync is not reported as a successful apply.
+	if res.State == "error" {
+		return &res, fmt.Errorf("%s firewall action %d reported state %q", action, res.ID, res.State)
+	}
+	return &res, nil
+}

--- a/hostinger/vps_firewall_test.go
+++ b/hostinger/vps_firewall_test.go
@@ -1,0 +1,385 @@
+package hostinger
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func newTestClient(server *httptest.Server) *HostingerClient {
+	return &HostingerClient{
+		BaseURL:    server.URL,
+		HTTPClient: http.DefaultClient,
+		Token:      "test-token",
+	}
+}
+
+func TestResourceHostingerVPSFirewall_Schema(t *testing.T) {
+	res := resourceHostingerVPSFirewall()
+
+	if err := res.InternalValidate(res.Schema, true); err != nil {
+		t.Fatalf("schema validation failed: %s", err)
+	}
+
+	for _, field := range []string{"name", "rule", "is_synced", "created_at", "updated_at"} {
+		if _, ok := res.Schema[field]; !ok {
+			t.Errorf("expected field %q not found in schema", field)
+		}
+	}
+
+	if !res.Schema["name"].ForceNew {
+		t.Errorf("expected name to be ForceNew")
+	}
+
+	ruleElem := res.Schema["rule"].Elem.(*schema.Resource)
+	if !ruleElem.Schema["action"].Computed {
+		t.Errorf("expected rule.action to be Computed")
+	}
+	if !ruleElem.Schema["id"].Computed {
+		t.Errorf("expected rule.id to be Computed")
+	}
+}
+
+func TestResourceHostingerVPSFirewallActivation_Schema(t *testing.T) {
+	res := resourceHostingerVPSFirewallActivation()
+
+	if err := res.InternalValidate(res.Schema, true); err != nil {
+		t.Fatalf("schema validation failed: %s", err)
+	}
+
+	for _, field := range []string{"firewall_id", "virtual_machine_id", "triggers", "is_synced"} {
+		if _, ok := res.Schema[field]; !ok {
+			t.Errorf("expected field %q not found in schema", field)
+		}
+	}
+
+	if !res.Schema["firewall_id"].ForceNew || !res.Schema["virtual_machine_id"].ForceNew {
+		t.Errorf("expected firewall_id and virtual_machine_id to be ForceNew")
+	}
+	if !res.Schema["is_synced"].Computed {
+		t.Errorf("expected is_synced to be Computed")
+	}
+}
+
+func TestCreateFirewall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/vps/v1/firewall" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["name"] != "web-fw" {
+			t.Errorf("expected name 'web-fw', got %v", body["name"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":65224,"name":"web-fw","is_synced":false,"rules":[]}`))
+	}))
+	defer server.Close()
+
+	fw, err := newTestClient(server).CreateFirewall("web-fw")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fw.ID != 65224 || fw.Name != "web-fw" {
+		t.Errorf("unexpected firewall: %+v", fw)
+	}
+}
+
+func TestGetFirewall_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := newTestClient(server).GetFirewall(999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreateFirewallRule(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/vps/v1/firewall/65224/rules" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		// The create request must carry only the four user fields.
+		for _, want := range []string{"protocol", "port", "source", "source_detail"} {
+			if _, ok := body[want]; !ok {
+				t.Errorf("expected request body to contain %q", want)
+			}
+		}
+		// action and id are read-only and must not be sent.
+		if _, ok := body["action"]; ok {
+			t.Errorf("request body must not contain 'action'")
+		}
+		if _, ok := body["id"]; ok {
+			t.Errorf("request body must not contain 'id'")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":24541,"action":"accept","protocol":"HTTPS","port":"443","source":"any","source_detail":"any"}`))
+	}))
+	defer server.Close()
+
+	rule, err := newTestClient(server).CreateFirewallRule(65224, FirewallRule{
+		Protocol:     "HTTPS",
+		Port:         "443",
+		Source:       "any",
+		SourceDetail: "any",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rule.ID != 24541 || rule.Action != "accept" {
+		t.Errorf("unexpected rule: %+v", rule)
+	}
+}
+
+func TestDeleteFirewallRule(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/vps/v1/firewall/65224/rules/24541" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"deleted"}`))
+	}))
+	defer server.Close()
+
+	if err := newTestClient(server).DeleteFirewallRule(65224, 24541); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestFirewallVMActions(t *testing.T) {
+	for _, action := range []string{"activate", "deactivate", "sync"} {
+		t.Run(action, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				want := "/api/vps/v1/firewall/65224/" + action + "/1268054"
+				if r.Method != http.MethodPost || r.URL.Path != want {
+					t.Fatalf("unexpected request: %s %s (want POST %s)", r.Method, r.URL.Path, want)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":8123712,"name":"action_name","state":"success"}`))
+			}))
+			defer server.Close()
+
+			client := newTestClient(server)
+			var (
+				res *FirewallAction
+				err error
+			)
+			switch action {
+			case "activate":
+				res, err = client.ActivateFirewall(65224, 1268054)
+			case "deactivate":
+				res, err = client.DeactivateFirewall(65224, 1268054)
+			case "sync":
+				res, err = client.SyncFirewall(65224, 1268054)
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if res.State != "success" {
+				t.Errorf("expected state 'success', got %q", res.State)
+			}
+		})
+	}
+}
+
+func TestUpdateFirewallRule(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/vps/v1/firewall/65224/rules/24541" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["port"] != "8443" {
+			t.Errorf("expected updated port '8443', got %v", body["port"])
+		}
+		// action and id are read-only and must not be sent.
+		if _, ok := body["action"]; ok {
+			t.Errorf("request body must not contain 'action'")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":24541,"action":"accept","protocol":"HTTPS","port":"8443","source":"any","source_detail":"any"}`))
+	}))
+	defer server.Close()
+
+	rule, err := newTestClient(server).UpdateFirewallRule(65224, 24541, FirewallRule{
+		Protocol:     "HTTPS",
+		Port:         "8443",
+		Source:       "any",
+		SourceDetail: "any",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rule.ID != 24541 || rule.Port != "8443" {
+		t.Errorf("unexpected rule: %+v", rule)
+	}
+}
+
+func TestPlanFirewallRuleChanges(t *testing.T) {
+	rule := func(id int, proto, port string) map[string]interface{} {
+		return map[string]interface{}{
+			"id":            id,
+			"action":        "accept",
+			"protocol":      proto,
+			"port":          port,
+			"source":        "any",
+			"source_detail": "any",
+		}
+	}
+	// State rules carry their server-assigned IDs; config rules (id 0) do not.
+	old := []interface{}{rule(1, "SSH", "22"), rule(2, "HTTPS", "443")}
+
+	// Edit in place: same length, one field changed -> one PUT keeping the ID.
+	edited := []interface{}{rule(0, "SSH", "22"), rule(0, "HTTPS", "8443")}
+	updates, creates, deletes := planFirewallRuleChanges(old, edited)
+	if len(updates) != 1 || updates[0].ID != 2 || updates[0].Rule.Port != "8443" {
+		t.Errorf("expected one in-place update of rule 2 to port 8443, got %+v", updates)
+	}
+	if len(creates) != 0 || len(deletes) != 0 {
+		t.Errorf("expected no creates/deletes, got creates=%v deletes=%v", creates, deletes)
+	}
+
+	// Append: new list longer -> one create.
+	grown := []interface{}{rule(0, "SSH", "22"), rule(0, "HTTPS", "443"), rule(0, "TCP", "8080")}
+	updates, creates, deletes = planFirewallRuleChanges(old, grown)
+	if len(creates) != 1 || creates[0].Port != "8080" || len(updates) != 0 || len(deletes) != 0 {
+		t.Errorf("expected one create, got updates=%v creates=%v deletes=%v", updates, creates, deletes)
+	}
+
+	// Shrink: old list longer -> delete trailing rule by ID.
+	shrunk := []interface{}{rule(0, "SSH", "22")}
+	updates, creates, deletes = planFirewallRuleChanges(old, shrunk)
+	if len(deletes) != 1 || deletes[0] != 2 || len(updates) != 0 || len(creates) != 0 {
+		t.Errorf("expected one delete of rule 2, got updates=%v creates=%v deletes=%v", updates, creates, deletes)
+	}
+
+	// No change -> no API calls (computed id/action must not trigger an update).
+	same := []interface{}{rule(0, "SSH", "22"), rule(0, "HTTPS", "443")}
+	updates, creates, deletes = planFirewallRuleChanges(old, same)
+	if len(updates) != 0 || len(creates) != 0 || len(deletes) != 0 {
+		t.Errorf("expected no changes, got updates=%v creates=%v deletes=%v", updates, creates, deletes)
+	}
+}
+
+func TestParseFirewallActivationID(t *testing.T) {
+	fwID, vmID, err := parseFirewallActivationID("65224/1268054")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fwID != 65224 || vmID != 1268054 {
+		t.Errorf("unexpected parse result: fw=%d vm=%d", fwID, vmID)
+	}
+
+	for _, bad := range []string{"bad", "65224", "65224/1268054/3", "abc/1", "1/def"} {
+		if _, _, err := parseFirewallActivationID(bad); err == nil {
+			t.Errorf("expected error for invalid ID %q", bad)
+		}
+	}
+}
+
+func TestValidateFirewallPort(t *testing.T) {
+	valid := []string{"1", "443", "65535", "1024:2048", "22:22"}
+	for _, p := range valid {
+		if _, errs := validateFirewallPort(p, "port"); len(errs) > 0 {
+			t.Errorf("expected %q to be valid, got %v", p, errs)
+		}
+	}
+
+	// 0 and 65536/99999 are out of range; reversed ranges and malformed inputs are rejected.
+	invalid := []string{"0", "65536", "99999", "2048:1024", "", "abc", "1:2:3", "443:", ":443", "-1"}
+	for _, p := range invalid {
+		if _, errs := validateFirewallPort(p, "port"); len(errs) == 0 {
+			t.Errorf("expected %q to be invalid", p)
+		}
+	}
+}
+
+func TestFirewallVMAction_ErrorState(t *testing.T) {
+	// A 200 carrying an "error" action state must surface as an error, not a silent success.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":8123712,"name":"action_name","state":"error"}`))
+	}))
+	defer server.Close()
+
+	if _, err := newTestClient(server).ActivateFirewall(65224, 1268054); err == nil {
+		t.Fatal("expected an error when the action reports state 'error', got nil")
+	}
+}
+
+func TestFirewallActivationRead_DriftDetection(t *testing.T) {
+	const (
+		firewallID = 65224
+		vmID       = 1268054
+		id         = "65224/1268054"
+	)
+
+	// handler serves the VM detail with the given firewall_group_id JSON literal
+	// (e.g. "65224" or "null"), plus the firewall detail.
+	newServer := func(fwGroupID string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/vps/v1/virtual-machines/1268054":
+				_, _ = w.Write([]byte(`{"id":1268054,"firewall_group_id":` + fwGroupID + `}`))
+			case "/api/vps/v1/firewall/65224":
+				_, _ = w.Write([]byte(`{"id":65224,"name":"web-fw","is_synced":true,"rules":[]}`))
+			default:
+				t.Errorf("unexpected request path %q", r.URL.Path)
+			}
+		}))
+	}
+
+	read := func(server *httptest.Server) *schema.ResourceData {
+		d := resourceHostingerVPSFirewallActivation().TestResourceData()
+		d.SetId(id)
+		if diags := resourceHostingerVPSFirewallActivationRead(context.Background(), d, newTestClient(server)); diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		return d
+	}
+
+	t.Run("active on this VM keeps the resource", func(t *testing.T) {
+		server := newServer("65224")
+		defer server.Close()
+		d := read(server)
+		if d.Id() != id {
+			t.Errorf("expected ID %q to be retained, got %q", id, d.Id())
+		}
+		if !d.Get("is_synced").(bool) {
+			t.Errorf("expected is_synced to be true")
+		}
+	})
+
+	t.Run("disabled on this VM clears the resource", func(t *testing.T) {
+		server := newServer("null")
+		defer server.Close()
+		if d := read(server); d.Id() != "" {
+			t.Errorf("expected ID to be cleared on drift, got %q", d.Id())
+		}
+	})
+
+	t.Run("different firewall active clears the resource", func(t *testing.T) {
+		server := newServer("99999")
+		defer server.Close()
+		if d := read(server); d.Id() != "" {
+			t.Errorf("expected ID to be cleared when another firewall is active, got %q", d.Id())
+		}
+	})
+}


### PR DESCRIPTION
This pull request introduces support for managing VPS firewalls and their activation on Hostinger virtual machines via new Terraform resources. It adds the `hostinger_vps_firewall` and `hostinger_vps_firewall_activation` resources, complete with documentation and examples, and updates the provider to register these resources. Additionally, it includes minor improvements to workflow and release configuration files.

**New Firewall Resource Support**

* Added the `hostinger_vps_firewall` resource, enabling users to define firewalls and ordered accept rules for Hostinger VPS instances. Documentation and import instructions are included.
* Added the `hostinger_vps_firewall_activation` resource, allowing activation (and deactivation) of firewalls on specific VMs, with support for syncing rule changes. Documentation and import instructions are provided. [[1]](diffhunk://#diff-d8873516dfcc6104955256912f1a6ddcb9bcf1c3f40201ed49ab1a9ebf85bbc8R1-R50) [[2]](diffhunk://#diff-633e27d97ad16e69a0b6deeaac65c8cbdd80cae39b38f235ac07e903bdf12abbR1-R225)
* Registered both new resources in the provider so they are available for use in Terraform configurations.
* Updated the `VirtualMachine` struct to expose the currently active firewall group ID, supporting drift detection and resource state management.

**Examples and Documentation**

* Added a complete example (`firewall.tf`) demonstrating how to create a firewall, define rules, activate it on a VM, and handle syncing.
* Updated the main resource table in `docs/index.md` to list the new firewall resources.

**Workflow and Release Improvements**

* Changed the Go setup in the lint workflow to use the version specified in `go.mod` for better consistency.
* Updated the archive format configuration in `.goreleaser.yml` for improved clarity and compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hostinger_vps_firewall` resource for managing VPS firewall rules with support for multiple protocols and ports.
  * Added `hostinger_vps_firewall_activation` resource to attach and sync firewalls to virtual machines.

* **Documentation**
  * Added comprehensive documentation for both firewall resources.
  * Added example configuration demonstrating VPS firewall setup and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->